### PR TITLE
Fix XML <label> Tag Serialization Issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>org.jflap</groupId>
 	<artifactId>jflap</artifactId>
 	<packaging>jar</packaging>
-	<version>7.0</version>
+	<version>7.1</version>
 
 
 	<name>JFLAP</name>

--- a/src/file/xml/AutomatonTransducer.java
+++ b/src/file/xml/AutomatonTransducer.java
@@ -591,6 +591,7 @@ public abstract class AutomatonTransducer extends AbstractTransducer {
 				+ block.getPoint().getX()));
 		be.appendChild(createElement(document, STATE_Y_COORD_NAME, null, ""
 				+ block.getPoint().getY()));
+		be.appendChild(createElement(document, STATE_LABEL_NAME, null, block.getLabel()));
 		// Encode whether the block is initial.
 //		State parent = block.getParentBlock();
 //		Automaton a = null;


### PR DESCRIPTION
Resolved a issue where the <label> tag in XML was not properly saved, leading to data loss when reloading the project. This fix ensures that the <label> tag is correctly serialized and preserved across project sessions.
